### PR TITLE
- fix for revealableView appearing on the right side of the cells by default

### DIFF
--- a/iMessageStyleReveal/SPXRevealableView/UITableView+SPXRevealAdditions.m
+++ b/iMessageStyleReveal/SPXRevealableView/UITableView+SPXRevealAdditions.m
@@ -236,7 +236,7 @@ static CGFloat currentOffset;
   objc_setAssociatedObject(self, SPXRevealableView, revealableView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
   
   [self addSubview:revealableView];
-  [self updateRevealableViewFrameForDirection:SPXRevealableViewGestureDirectionLeft];
+  [self updateRevealableViewFrameForDirection:SPXRevealableViewGestureDirectionRight];
 }
 
 @end

--- a/iMessageStyleReveal/SPXRevealableView/UITableView+SPXRevealAdditions.m
+++ b/iMessageStyleReveal/SPXRevealableView/UITableView+SPXRevealAdditions.m
@@ -156,11 +156,8 @@ static CGFloat currentOffset;
     default:
     {
       [UIView animateWithDuration:0.3 animations:^{
-        for (UITableViewCell *cell in self.visibleCells) {
           currentOffset = 0;
-          
           [self updateFramesForCells];
-        }
       } completion:^(BOOL finished) {
         translationX = 0;
       }];


### PR DESCRIPTION
I found a problem that revealableView is not being update for the first time after it gets added.
Problem is also visible in example provided to the project - if you make:
```
self.tableView.clipsToBounds = NO;
...
cell.clipsToBounds = NO;
```
and rotate the iPhone you get this:

![ios simulator screen shot 11 sep 2015 15 20 30](https://cloud.githubusercontent.com/assets/1301068/9815792/03d52f6a-5899-11e5-94c8-4258b8655277.png)

Eventhough I want to have date on the left side - problem is that bounds of cell is not calculated properly during cellForRow when using autolayout.

Best will be to update position of revealableView when frame of cell is changing, but a quick fix is to place them by default on the left side.